### PR TITLE
Remove cells border in the library

### DIFF
--- a/html_src/css/skin/default.css
+++ b/html_src/css/skin/default.css
@@ -452,6 +452,9 @@ padding-left: 5px;
 word-wrap: break-word;
 white-space: normal;
 }
+table.jukebox-search-table td{
+border: 0;
+}
 table.jukebox-upload-table th{
 word-wrap: normal;
 white-space: nowrap;


### PR DESCRIPTION
Y'a un bug FireFox actuellement qui fait que le cellules de tableau en border-collapse n'ont plus de bordure.
https://bugzilla.mozilla.org/show_bug.cgi?id=1000435
(from https://bugzilla.mozilla.org/show_bug.cgi?id=244135)
Mais finalement on préfère ce style pour tous les browsers, donc je passe border à 0
N'impacte pas l'onglet upload
